### PR TITLE
Added git-badges for visitor count

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@
 ## Tools
 - [Visitor Badge](https://visitor-badge.glitch.me/#docs) - Count visitors for your README.md, Issues, PRs in GitHub
 - [1990s style Visitor Counter](https://twitter.com/ryanlanciaux/status/1283755637126705152) - Add a 1990s style visitor counter with one line of markdown.
+- [Vists Count](https://pufler.dev/git-badges/) - Count visitors for README.md that can be used with shields.io
 - [Shields Project](https://shields.io/) - Use Shields to create profile badges, compatible with Simple Icons
 - [Github Readme Stats](https://github.com/anuraghazra/github-readme-stats) - Get dynamically generated GitHub stats on your readmes
 - [Simple Icons](https://github.com/simple-icons/simple-icons#cdn-usage) -  SVG icons for popular brands for your README.md files


### PR DESCRIPTION
Alternate to visitor-badge.glitch.me which went down recently. Reference: https://dev.to/puf17640/comment/125ja

## What type of PR is this? (check all applicable)


- [ ] 🚀 Added Name
- [x] ✨ Feature
- [ ] ✅ Joined Community
- [x] 🌟 ed the repo
- [ ] 🐛 Grammatical Error
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

Added an alternate visits counter to the current suggested one (hosted on glitch.io and went down recently https://github.com/jwenjian/visitor-badge/issues/2). According to the dev of this one, it is hosted on a dedicated server and won't get any rate-limit downtime (https://dev.to/puf17640/comment/125ja). @puf17640


