### PR TITLE
Add Samujjwaal Dey to Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@
 - [Brendon Smith](https://github.com/br3ndonland/br3ndonland)
 - [Alwin Wang](https://github.com/alwinw/alwinw)
 - [Ileriayo Adebiyi](https://github.com/ileriayo/ileriayo)
+- [Samujjwaal Dey](https://github.com/samujjwaal/samujjwaal)
 
 #### Fancy Fonts 🖋
 - [xiaoluoboding](https://github.com/xiaoluoboding/xiaoluoboding)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)


- [x] 🚀 Added Name
- [ ] ✨ Feature
- [ ] ✅ Joined Community
- [x] 🌟 ed the repo
- [ ] 🐛 Grammatical Error
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description
Adding Samujjwaal Dey's profile readme under the [Badges](https://github.com/abhisheknaiidu/awesome-github-profile-readme#badges-) category. Badges have been used to add links to social accounts. 
Additionally, images and [Github Readme Stats](https://github.com/anuraghazra/github-readme-stats) also added to the profile readme.

So profile could be also added under [Dynamic Realtime](https://github.com/abhisheknaiidu/awesome-github-profile-readme#dynamic-realtime-) category. 
Please do suggest a category accordingly.

## Add Link of GitHub Profile
[Samujjwaal Dey](https://github.com/samujjwaal/samujjwaal)

