### PR TITLE
fix broken profile link: qu4k -> filipporeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@
 - [Jessica Lim](https://github.com/JessicaLim8/JessicaLim8)
 - [侑夕-Tw93](https://github.com/tw93/tw93)
 - [liununu](https://github.com/liununu/liununu)
-- [Filippo Rossi (qu4k)](https://github.com/qu4k/qu4k)
+- [Filippo Rossi (qu4k)](https://github.com/filipporeds/filipporeds)
 - [Moe Poi ~](https://github.com/moepoi/moepoi)
 - [Elon Tang (blackcater)](https://github.com/blackcater/blackcater)
 - [Stanley Lim (Spiderpig86)](https://github.com/Spiderpig86/Spiderpig86)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 📝 Documentation Update

## Description
While checking [awesomegithubprofile.tech](https://awesomegithubprofile.tech/) I came across this broken profile url [qu4k](https://github.com/qu4k).

Looks like the user has update its username from `qu4k` to `filipporeds`.

Took me a quick search by user name (Filippo Rossi) to find the new profile url.

Also: if you visit https://github.com/qu4k/qu4k you will be redirected to https://github.com/filipporeds/filipporeds

## Add Link of GitHub Profile
https://github.com/filipporeds
