### PR TITLE
Remove jatin2003

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@
 - [Danny Koppenhagen](https://github.com/d-koppenhagen/d-koppenhagen)
 - [Vidya Bhandary](https://github.com/vidyabhandary/vidyabhandary)
 - [Rao Hai](https://github.com/RaoHai/RaoHai)
-- [Jatin Rao](https://github.com/jatin2003/jatin2003)
 - [teoxoy](https://github.com/teoxoy/teoxoy)
 - [Aral Roca](https://github.com/aralroca/aralroca)
 - [codeSTACKr](https://github.com/codestackr/codestackr)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🚀 Added Name
- [ ] ✨ Feature
- [ ] ✅ Joined Community
- [ ] 🌟 ed the repo
- [ ] 🐛 Grammatical Error
- [ ] 📝 Documentation Update
- [x] 🚩 Other

## Description
I scrolled through the [website](https://awesomegithubprofile.tech/) and noticed that the [following profile](https://github.com/jatin2003/jatin2003) was not very "awesome".

Seems like the once awesome GitHub profile got changed and now it just says "Hello!":
https://github.com/jatin2003/jatin2003/commit/8b804d0a833de05f2f4e0c6b07806ee5caee9fc8
https://github.com/jatin2003/jatin2003/commit/3a4415edd92194893eaac9ee6807b8efce83ef5a

So let's remove it.

## Add Link of GitHub Profile
https://github.com/jatin2003/jatin2003