### PR TITLE
Added Discord Activity Badge in Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@
 - [Simple Icons](https://github.com/simple-icons/simple-icons#cdn-usage) -  SVG icons for popular brands for your README.md files
 - [Laravel GitHub Profile Visit Counter](https://github.com/caneco/laravel-github-profile-view-counter) - Add on your Laravel project a quick-badge to count your profile visits.
 - [Dev Metrics in Readme](https://github.com/athul/waka-readme) - [WakaTime](https://wakatime.com/) Weekly Metrics on your Profile Readme
+- [Discord Activity Badge](https://github.com/CodexLink/discord-activity-badge) - Bridge your Discord State and Activities to a Representable Badge on your repository to show your current status in your Profile README.
 - [Profile Activity Generator](https://github.com/omidnikrah/profile-activity-generator) - Generate custom profile activity for your profile README
 - [Current UTC time](https://github.com/jojoee/jojoee) - Example code of server that can serve dynamic content on GitHub profile
 - [Github Activity in README](https://github.com/jamesgeorge007/github-activity-readme) - Updates `README.md` with the recent GitHub activity of a user


### PR DESCRIPTION
## What type of PR is this? (check all applicable)


- [X] 🚀 Added Name
- [ ] ✨ Feature
- [ ] ✅ Joined Community
- [X] 🌟 ed the repo
- [ ] 🐛 Grammatical Error
- [X] 📝 Documentation Update
- [ ] 🚩 Other

I added my work named `Discord Activity Badge` in the Tools Section, the main point of this work was to bridge your Discord's State and Activities to a representable static badge that gets updated by a workflow (actually in Cached Docker Container) over time.



For Demo (Please check the badge on top): https://github.com/CodexLink/CodexLink

