### PR TITLE
Add GitHub Action `readme-scribe` to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 - [codeSTACKr](https://github.com/codestackr/codestackr)
 - [itgoyo](https://github.com/itgoyo/itgoyo)
 - [lifeparticle](https://github.com/lifeparticle/lifeparticle)
+- [Michael Schnerring](https://github.com/schnerring/schnerring)
 
 #### Game Mode 🚀
 - [Tim Burgan](https://github.com/timburgan/timburgan)
@@ -317,6 +318,7 @@
 - [YouTube Channel Stats](https://github.com/DenverCoder1/github-readme-youtube-stats) - 📺 Display number of subscribers on YouTube and/or your channel's view count as a badge
 - [Current Book Status from GoodReads](https://github.com/theFr1nge/goodreads-readme) - Add a card of the current book you are reading that automatically syncs with GoodReads to display your progress.
 - [Readme Typing SVG](https://github.com/DenverCoder1/readme-typing-svg) - :zap: Dynamically generated, customizable SVG that gives the appearance of typing and deleting text
+- [readme-scribe](https://github.com/muesli/readme-scribe) - A GitHub Action that automatically generates & updates markdown content (like your README.md)
 
 ## Articles
 - ["How To Create A GitHub Profile README"](https://www.aboutmonica.com/blog/how-to-create-a-github-profile-readme) - *Monica Powell*


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🚀 Added Name
- [x] ✨ Feature
- [ ] ✅ Joined Community
- [ ] 🌟 ed the repo
- [ ] 🐛 Grammatical Error
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

I added the the really cool [readme-scribe](https://github.com/muesli/readme-scribe) action to the tools section. I use it to generate my profile README, so I've also added myself as an example.

## Add Link of GitHub Profile

https://github.com/schnerring