### PR TITLE
added 📌 github-readme-topics-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@
 - [YouTube Channel Stats](https://github.com/DenverCoder1/github-readme-youtube-stats) - 📺 Display number of subscribers on YouTube and/or your channel's view count as a badge
 - [Current Book Status from GoodReads](https://github.com/theFr1nge/goodreads-readme) - Add a card of the current book you are reading that automatically syncs with GoodReads to display your progress.
 - [Readme Typing SVG](https://github.com/DenverCoder1/readme-typing-svg) - :zap: Dynamically generated, customizable SVG that gives the appearance of typing and deleting text
+- [Readme Topics Action](https://github.com/metaory/github-readme-topics-action) - :pushpin: GitHub Action to update GitHub profile README.md with categorized repos based on their Topics
 
 ## Articles
 - ["How To Create A GitHub Profile README"](https://www.aboutmonica.com/blog/how-to-create-a-github-profile-readme) - *Monica Powell*


### PR DESCRIPTION
### :pushpin: Action to generate GitHub profile readme repos pin based on Topics

## What type of PR is this? (check all applicable)


- [x] 🚀 Added Name
- [x] ✨ Feature
- [x] ✅ Joined Community
- [x] 🌟 ed the repo
- [x] 🐛 Grammatical Error
- [x] 📝 Documentation Update
- [ ] 🚩 Other

## Description

:pushpin: Action to generate GitHub profile readme repos pin based on Topics

<p align="center">
  <img src="https://raw.githubusercontent.com/metaory/github-readme-topics-action/master/assets/screenshot.png" width="600" />
</p>


## Add Link of GitHub Profile

- [github-readme-topics-action ](https://github.com/metaory/github-readme-topics-action)
- [example-profile](https://github.com/metaory/metaory)