### PR TITLE
Removed the profile link which are no more available

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@
 - [Zhenye Na](https://github.com/Zhenye-Na/Zhenye-Na)
 
 #### Dynamic Realtime 💫
-- [Kirill Feschenko](https://github.com/xcaq/xcaq)
 - [Anurag Hazra](https://github.com/anuraghazra/anuraghazra)
 - [DenverCoder1](https://github.com/DenverCoder1/DenverCoder1)
 - [Hemant Joshi](https://github.com/8bithemant/8bithemant)


### PR DESCRIPTION


## What type of PR is this? (check all applicable)


- [ ] 🚀 Added Name
- [ ] ✨ Feature
- [ ] ✅ Joined Community
- [ ] 🌟 ed the repo
- [ ] 🐛 Grammatical Error
- [X] 📝 Documentation Update
- [ ] 🚩 Other

## Description

- Removed Kirill Feschenko Github Profile
- His profile is no more available
- Check it here https://github.com/xcaq/xcaq

## Add Link of GitHub Profile

