### PR TITLE
Add Tool: Display IDE coding stats as wakatime stats cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@
 - [Christian Petersen](https://github.com/fnky/fnky)
 
 ## Tools
+- [WakaTime IDE Coding Time Stats](https://github.com/LauraAllObe/wakatimeReadmeStats) - Dynamically generated WakaTime coding stats for your README: heatmaps, ranks, weekly coding time, repos, languages, and more.
 - [Todoist Stats in Readme](https://github.com/abhisheknaiidu/todoist-readme) - Daily Todoist Stats on your Profile Readme
 - [Visitor Badge](https://visitor-badge.glitch.me/#docs) - Count visitors for your README.md, Issues, PRs in GitHub
 - [1990s style Visitor Counter](https://twitter.com/ryanlanciaux/status/1283755637126705152) - Add a 1990s style visitor counter with one line of markdown.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)


- [ ] 🚀 Added Name
- [X] ✨ Feature
- [ ] ✅ Joined Community
- [ ] 🌟 ed the repo
- [ ] 🐛 Grammatical Error
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

Added a tool to the tools list. The tool allows the user to display their coding stats from their IDEs in their readmes. This uses the wakatime IDE extension and github actions. 31 customizable parameters present, 30 preset themes, 10 card types, 8 chart types (i.e. if weekly_avg card type is chosen, then the user can choose from 7/8 chart types, such as bar, bubble, line, ... to display their weekly average coding time).

## Add Link of GitHub Profile

https://github.com/LauraAllObe
