### PR TITLE
Add a GPRM to tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,8 @@
 - [YouTube Channel Stats](https://github.com/DenverCoder1/github-readme-youtube-stats) - 📺 Display number of subscribers on YouTube and/or your channel's view count as a badge
 - [Current Book Status from GoodReads](https://github.com/theFr1nge/goodreads-readme) - Add a card of the current book you are reading that automatically syncs with GoodReads to display your progress.
 - [Readme Typing SVG](https://github.com/DenverCoder1/readme-typing-svg) - :zap: Dynamically generated, customizable SVG that gives the appearance of typing and deleting text
+- [GPRM](https://github.com/VishwaGauravIn/github-profile-readme-maker) - A tool to generate a customized GitHub Profile README with a modern UI.
+
 
 ## Articles
 - ["How To Create A GitHub Profile README"](https://www.aboutmonica.com/blog/how-to-create-a-github-profile-readme) - *Monica Powell*


### PR DESCRIPTION
## What type of PR is this? 

Add a GPRM to tools section



## Description

This PR adds GPRM (GitHub Profile ReadMe Maker) to the Tools section.
It is a useful tool for generating a customized GitHub Profile README with a modern UI.
Tool URL : https://github.com/VishwaGauravIn/github-profile-readme-maker



