### PR TITLE
Add GitHub PR Stats tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@
 - [YouTube Channel Stats](https://github.com/DenverCoder1/github-readme-youtube-stats) - 📺 Display number of subscribers on YouTube and/or your channel's view count as a badge
 - [Current Book Status from GoodReads](https://github.com/theFr1nge/goodreads-readme) - Add a card of the current book you are reading that automatically syncs with GoodReads to display your progress.
 - [Readme Typing SVG](https://github.com/DenverCoder1/readme-typing-svg) - :zap: Dynamically generated, customizable SVG that gives the appearance of typing and deleting text
+- [GitHub PR Stats](https://github.com/f14XuanLv/github-pr-stats) - 📊 Showcase your merged pull requests from prestigious projects with beautiful SVG tables. Filter by repository stars to highlight high-impact contributions.
 
 ## Articles
 - ["How To Create A GitHub Profile README"](https://www.aboutmonica.com/blog/how-to-create-a-github-profile-readme) - *Monica Powell*


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🚀 Added Name
- [ ] ✨ Feature
- [ ] ✅ Joined Community
- [ ] 🌟 ed the repo
- [ ] 🐛 Grammatical Error
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

Add GitHub PR Stats to the Tools section. This tool transforms scattered GitHub PR contributions into beautiful, shareable SVG statistics cards. 

Features:
- Two display modes: PR timeline and repository overview
- Light/Dark themes  
- Smart filtering by stars, status, and more
- Visual web interface for easy configuration
- Fast loading with Redis caching

### 📊 PR List Mode - Your Contribution Timeline
![PR List Demo](https://github-pr-stats-five.vercel.app/api/github-pr-stats?username=f14xuanlv&limit=6&theme=dark)

### 📈 Repository Stats Mode - Impact Overview  
![Repo Stats Demo](https://github-pr-stats-five.vercel.app/api/github-pr-stats?username=torvalds&mode=repo-aggregate&limit=5&theme=dark)
*Using Linux creator Linus Torvalds' public PR data for technical demonstration*

## Add Link of GitHub Profile

https://github.com/f14XuanLv