### PR TITLE
Add Github + Wakatime Stats Cards under Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@
 - [Dani Akash](https://github.com/daniakash/daniakash)
 - [Rahul Jha](https://github.com/rahul-jha98/rahul-jha98)
 - [Taehyun Hwang](https://github.com/HwangTaehyun/HwangTaehyun)
+- [Laura Lovelace](https://github.com/LauraAllObe/LauraAllObe)
 
 #### A Little Bit of Everything 😃
 - [Raymond Li](https://github.com/Raymo111/Raymo111)
@@ -282,6 +283,7 @@
 - [Vistor Count](https://pufler.dev/git-badges/) - Count visitors for README.md that can be used with shields.io
 - [Shields Project](https://shields.io/) - Use Shields to create profile badges, compatible with Simple Icons
 - [Github Readme Stats](https://github.com/anuraghazra/github-readme-stats) - Get dynamically generated GitHub stats on your readmes
+- [Github + Wakatime Readme Stats](https://github.com/LauraAllObe/wakatimeReadmeStats) - Get dynamically generated GitHub + Wakatime stats on your readmes
 - [Github Contributor Stats](https://github.com/HwangTaehyun/github-contributor-stats) - :fire: Get dynamically generated Github Contributor stats (repositories you really committed) on your readmes
 - [GitHub Streak Stats](https://github.com/DenverCoder1/github-readme-streak-stats) - 🔥 Stay motivated and show off your contribution streak! 🌟 Display your total contributions, current streak, and longest streak on your GitHub profile README
 - [Simple Icons](https://github.com/simple-icons/simple-icons#cdn-usage) -  SVG icons for popular brands for your README.md files


### PR DESCRIPTION
## What type of PR is this? (check all applicable)


- [X] 🚀 Added Name
- [ ] ✨ Feature
- [X] ✅ Joined Community
- [X] 🌟 ed the repo
- [ ] 🐛 Grammatical Error
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description
@abhisheknaiidu I made this tool inspired by [github-readme-stats](https://github.com/anuraghazra/github-readme-stats) to display coding time from both github and a user's IDE using wakatime. Theres over 47 customization parameters total, 30 themes, 10 card types, 8 chart types (on chart cards) and an easy-to-follow setup tutorial. I've included some basic examples below, along with a video of it's usage on my github profile.
<div align="center">
<img  width="250" alt="Stats Card Example 1" src="https://github.com/user-attachments/assets/e10c4c18-0e5c-462a-83a8-7b875f60c9eb" />
<img  width="250" alt="Stats Card Example 2" src="https://github.com/user-attachments/assets/fe57628e-0efe-45eb-b621-883fdbb0f671" />
<img width="250" alt="Stats Card Example 3" src="https://github.com/user-attachments/assets/c46a3eae-c962-4113-90bc-bd2807b2d2cc" />
<img align="center" width="750" alt="Profile Readme with Cards" src="https://github.com/user-attachments/assets/359728ab-23c2-4d64-9e12-d65141ac9d14" />
</div>

## Add Link of GitHub Profile
[https://github.com/LauraAllObe/LauraAllObe](https://github.com/LauraAllObe/LauraAllObe)
