### PR TITLE
Add Last.fm Github Profile tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,28 +25,29 @@
 </div>
 
 ### Contents:
-  - [Categories](#categories)
-      - [GitHub Actions 🤖](#github-actions-)
-      - [Game Mode 🚀](#game-mode-)
-      - [Code Mode 👨🏽‍💻](#code-mode-)
-      - [Dynamic Realtime 💫](#dynamic-realtime-)
-      - [A Little Bit of Everything 😃](#a-little-bit-of-everything-)
-      - [Descriptive 🗒](#descriptive-)
-      - [Simple but Innovative Ones 🤗](#simple-but-innovative-ones-)
-      - [Typing.. Mode 🎰](#typing-mode-)
-      - [Anime 👾](#anime-)
-      - [Minimalistic ✨](#minimalistic-)
-      - [GIFS 👻](#gifs-)
-      - [Just Images 🎭](#just-images-)
-      - [Badges 🎫](#badges-)
-      - [Fancy Fonts 🖋](#fancy-fonts-)
-      - [Icons 🎯](#icons-)
-      - [Retro 😎](#retro-)
-  - [Tools](#tools)
-  - [Articles](#articles)
-  - [Video Tutorials](#tutorials)
-  - [Contribute](#contribute)
-  - [License](#license)
+- [Categories](#categories)
+    - [GitHub Actions 🤖](#github-actions-)
+    - [Game Mode 🚀](#game-mode-)
+    - [Code Mode 👨🏽‍💻](#code-mode-)
+    - [Dynamic Realtime 💫](#dynamic-realtime-)
+    - [A Little Bit of Everything 😃](#a-little-bit-of-everything-)
+    - [Descriptive 🗒](#descriptive-)
+    - [Simple but Innovative Ones 🤗](#simple-but-innovative-ones-)
+    - [Typing.. Mode 🎰](#typing-mode-)
+    - [Anime 👾](#anime-)
+    - [Minimalistic ✨](#minimalistic-)
+    - [GIFS 👻](#gifs-)
+    - [Just Images 🎭](#just-images-)
+    - [Badges 🎫](#badges-)
+    - [Fancy Fonts 🖋](#fancy-fonts-)
+    - [Icons 🎯](#icons-)
+    - [Retro 😎](#retro-)
+- [Tools](#tools)
+- [Articles](#articles)
+- [Tutorials](#tutorials)
+- [Contribute](#contribute)
+- [Special Thanks 🙇](#special-thanks-)
+- [License](#license)
 
 
 ## Categories
@@ -297,6 +298,7 @@
 - [Feedparser](https://pythonhosted.org/feedparser/) - Convenient processing of RSS files
 - [Profile README Widgets](https://github.com/marketplace/actions/profile-readme) - Add simple widgets to your profile readme.
 - [Spotify now playing card generator](https://github.com/kittinan/spotify-github-profile) - Generate your Spotify now playing card for your GitHub profile
+- [Last.fm Github Profile](https://github.com/VLADos-IT/lastfm-github-profile) - Display your current Last.fm Obsession or Top Track in your GitHub profile.
 - [Markdown Badges](https://github.com/Ileriayo/markdown-badges) - Add badges to your profile.
 - [Latest Blog Posts and StackOverflow activity in readme](https://github.com/gautamkrishnar/blog-post-workflow) - Show your latest blog posts from any sources or StackOverflow activity on your GitHub profile/project readme automatically using the RSS feed using this Github Action
 - [GitHub Readme LinkedIn](https://github.com/soroushchehresa/github-readme-linkedin) - Get dynamically generated images from your LinkedIn profile on your GitHub readmes

--- a/README.md
+++ b/README.md
@@ -25,29 +25,28 @@
 </div>
 
 ### Contents:
-- [Categories](#categories)
-    - [GitHub Actions 🤖](#github-actions-)
-    - [Game Mode 🚀](#game-mode-)
-    - [Code Mode 👨🏽‍💻](#code-mode-)
-    - [Dynamic Realtime 💫](#dynamic-realtime-)
-    - [A Little Bit of Everything 😃](#a-little-bit-of-everything-)
-    - [Descriptive 🗒](#descriptive-)
-    - [Simple but Innovative Ones 🤗](#simple-but-innovative-ones-)
-    - [Typing.. Mode 🎰](#typing-mode-)
-    - [Anime 👾](#anime-)
-    - [Minimalistic ✨](#minimalistic-)
-    - [GIFS 👻](#gifs-)
-    - [Just Images 🎭](#just-images-)
-    - [Badges 🎫](#badges-)
-    - [Fancy Fonts 🖋](#fancy-fonts-)
-    - [Icons 🎯](#icons-)
-    - [Retro 😎](#retro-)
-- [Tools](#tools)
-- [Articles](#articles)
-- [Tutorials](#tutorials)
-- [Contribute](#contribute)
-- [Special Thanks 🙇](#special-thanks-)
-- [License](#license)
+  - [Categories](#categories)
+      - [GitHub Actions 🤖](#github-actions-)
+      - [Game Mode 🚀](#game-mode-)
+      - [Code Mode 👨🏽‍💻](#code-mode-)
+      - [Dynamic Realtime 💫](#dynamic-realtime-)
+      - [A Little Bit of Everything 😃](#a-little-bit-of-everything-)
+      - [Descriptive 🗒](#descriptive-)
+      - [Simple but Innovative Ones 🤗](#simple-but-innovative-ones-)
+      - [Typing.. Mode 🎰](#typing-mode-)
+      - [Anime 👾](#anime-)
+      - [Minimalistic ✨](#minimalistic-)
+      - [GIFS 👻](#gifs-)
+      - [Just Images 🎭](#just-images-)
+      - [Badges 🎫](#badges-)
+      - [Fancy Fonts 🖋](#fancy-fonts-)
+      - [Icons 🎯](#icons-)
+      - [Retro 😎](#retro-)
+  - [Tools](#tools)
+  - [Articles](#articles)
+  - [Video Tutorials](#tutorials)
+  - [Contribute](#contribute)
+  - [License](#license)
 
 
 ## Categories
@@ -298,7 +297,7 @@
 - [Feedparser](https://pythonhosted.org/feedparser/) - Convenient processing of RSS files
 - [Profile README Widgets](https://github.com/marketplace/actions/profile-readme) - Add simple widgets to your profile readme.
 - [Spotify now playing card generator](https://github.com/kittinan/spotify-github-profile) - Generate your Spotify now playing card for your GitHub profile
-- [Last.fm Github Profile](https://github.com/VLADos-IT/lastfm-github-profile) - Display your current Last.fm Obsession or Top Track in your GitHub profile.
+- [Last.fm Github Profile](https://github.com/VLADos-IT/lastfm-github-profile) - Display your current Last.fm Obsession or Top Track in your GitHub profile
 - [Markdown Badges](https://github.com/Ileriayo/markdown-badges) - Add badges to your profile.
 - [Latest Blog Posts and StackOverflow activity in readme](https://github.com/gautamkrishnar/blog-post-workflow) - Show your latest blog posts from any sources or StackOverflow activity on your GitHub profile/project readme automatically using the RSS feed using this Github Action
 - [GitHub Readme LinkedIn](https://github.com/soroushchehresa/github-readme-linkedin) - Get dynamically generated images from your LinkedIn profile on your GitHub readmes


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🚀 Added Name
- [ ] ✨ Feature
- [ ] ✅ Joined Community
- [ ] 🌟 ed the repo
- [ ] 🐛 Grammatical Error
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

Add Last.fm Github Profile to the Tools section. This tool allows users to display their current Last.fm Obsession or Top Track directly in their GitHub README without requiring an API key.

**Features:**

- **No API Key Required**: Works by scraping public profile data, making setup instant.
- **Smart Mode**: Automatically displays "Current Obsession", falling back to "Top Track" if none is set.
- **Dynamic SVG**: Generates a lightweight SVG with a subtle wave animation.

![Example](https://lastfm-github-profile.vercel.app/api?user=vlados14311&bg=181818&mode=top)

## Add Link of GitHub Profile

<https://github.com/VLADos-IT>
