### PR TITLE
Add SoundBadge under Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@
 - [YouTube Channel Stats](https://github.com/DenverCoder1/github-readme-youtube-stats) - 📺 Display number of subscribers on YouTube and/or your channel's view count as a badge
 - [Current Book Status from GoodReads](https://github.com/theFr1nge/goodreads-readme) - Add a card of the current book you are reading that automatically syncs with GoodReads to display your progress.
 - [Readme Typing SVG](https://github.com/DenverCoder1/readme-typing-svg) - :zap: Dynamically generated, customizable SVG that gives the appearance of typing and deleting text
+- [SoundBadge](https://github.com/gguip1/SoundBadge) - Turn a YouTube link into a music taste badge for your GitHub profile. No auth required.
 
 ## Articles
 - ["How To Create A GitHub Profile README"](https://www.aboutmonica.com/blog/how-to-create-a-github-profile-readme) - *Monica Powell*


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🚀 Added Name
- [ ] ✨ Feature
- [x] ✅ Joined Community
- [x] 🌟 ed the repo
- [ ] 🐛 Grammatical Error
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

Added [SoundBadge](https://github.com/gguip1/SoundBadge) under the "Tools" section. It turns a YouTube link into a music taste badge (SVG) for your GitHub profile — no authentication required.

![SoundBadge Demo](https://sound-badge.vercel.app/api/card.svg?url=https://www.youtube.com/watch?v=dQw4w9WgXcQ&theme=stream&variant=purple)

## Add Link of GitHub Profile

https://github.com/gguip1/SoundBadge