### PR TITLE
Add Credly Badge README Updater to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@
 - [YouTube Channel Stats](https://github.com/DenverCoder1/github-readme-youtube-stats) - 📺 Display number of subscribers on YouTube and/or your channel's view count as a badge
 - [Current Book Status from GoodReads](https://github.com/theFr1nge/goodreads-readme) - Add a card of the current book you are reading that automatically syncs with GoodReads to display your progress.
 - [Readme Typing SVG](https://github.com/DenverCoder1/readme-typing-svg) - :zap: Dynamically generated, customizable SVG that gives the appearance of typing and deleting text
+- [Credly Badge README Updater](https://github.com/Sagargupta16/credly-badge-readme-action) - Auto-sync Credly certifications and badges to your GitHub profile README
 
 ## Articles
 - ["How To Create A GitHub Profile README"](https://www.aboutmonica.com/blog/how-to-create-a-github-profile-readme) - *Monica Powell*


### PR DESCRIPTION
## Description
Adds [Credly Badge README Updater](https://github.com/marketplace/actions/credly-badge-readme-updater) to the Tools section.

A GitHub Action that automatically syncs Credly certifications and badges to your GitHub profile README. It fetches badges from the Credly API, categorizes them, and updates the README between markers.

## Checklist
- [x] Tool is related to GitHub Profile READMEs
- [x] Published on GitHub Marketplace
- [x] Has documentation and examples
- [x] Follows the existing list format