### PR TITLE
Fix Code Mode anchor link encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
   - [Categories](#categories)
       - [GitHub Actions 🤖](#github-actions-)
       - [Game Mode 🚀](#game-mode-)
-      - [Code Mode 👨🏽‍💻](#code-mode-)
+      - [Code Mode 👨🏽‍💻](#code-mode-%E2%80%8D)
       - [Dynamic Realtime 💫](#dynamic-realtime-)
       - [A Little Bit of Everything 😃](#a-little-bit-of-everything-)
       - [Descriptive 🗒](#descriptive-)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)


- [ ] 🚀 Added Name
- [ ] ✨ Feature
- [ ] ✅ Joined Community
- [ ] 🌟 ed the repo
- [ ] 🐛 Grammatical Error
- [x] 📝 Documentation Update
- [x] 🚩 Other

## Description
Update README table of contents to use the percent-encoded zero-width joiner in the Code Mode anchor (#code-mode-%E2%80%8D). This ensures the TOC link matches the heading anchor generated by GitHub and resolves correctly.

## Add Link of GitHub Profile
https://github.com/jbakalarski
