### PR TITLE
Add terminal-identity to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@
 - [YouTube Channel Stats](https://github.com/DenverCoder1/github-readme-youtube-stats) - 📺 Display number of subscribers on YouTube and/or your channel's view count as a badge
 - [Current Book Status from GoodReads](https://github.com/theFr1nge/goodreads-readme) - Add a card of the current book you are reading that automatically syncs with GoodReads to display your progress.
 - [Readme Typing SVG](https://github.com/DenverCoder1/readme-typing-svg) - :zap: Dynamically generated, customizable SVG that gives the appearance of typing and deleting text
+- [Terminal Identity](https://github.com/doyoon530/terminal-identity) - Terminal-style SVG identity cards for GitHub READMEs, generated from a single URL
 
 ## Articles
 - ["How To Create A GitHub Profile README"](https://www.aboutmonica.com/blog/how-to-create-a-github-profile-readme) - *Monica Powell*


### PR DESCRIPTION

<img width="851" height="615" alt="스크린샷 2026-04-11 오후 12 45 42" src="https://github.com/user-attachments/assets/102369c5-47ab-47fa-bf17-010847261a9d" />

## Description

Adds [terminal-identity](https://github.com/doyoon530/terminal-identity) to the Tools section.

Terminal Identity is a highly customizable GitHub README card generator for creating terminal-style SVG profile cards with live GitHub stats, top languages, multiple shell styles, themes, and background patterns — all with a single image URL.

## Checklist
- [x] Added to the Tools section
- [x] Link is correct and repository is public
- [x] Description is clear and concise