### PR TITLE
Add Ghstats

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@
 - [Visitor Count](https://pufler.dev/badge-it/) - Count visitors for README.md that can be used with shields.io
 - [Shields Project](https://shields.io/) - Use Shields to create profile badges, compatible with Simple Icons
 - [Github Readme Stats](https://github.com/anuraghazra/github-readme-stats) - Get dynamically generated GitHub stats on your readmes
+- [Ghstats](https://github.com/tiennm99/ghstats) - Go CLI + GitHub Action that generates 9 themed SVG profile cards (61+ themes, byte-weighted commit-to-language attribution, all-time variants).
 - [Github Contributor Stats](https://github.com/HwangTaehyun/github-contributor-stats) - :fire: Get dynamically generated Github Contributor stats (repositories you really committed) on your readmes
 - [GitHub Streak Stats](https://github.com/DenverCoder1/github-readme-streak-stats) - 🔥 Stay motivated and show off your contribution streak! 🌟 Display your total contributions, current streak, and longest streak on your GitHub profile README
 - [Simple Icons](https://github.com/simple-icons/simple-icons#cdn-usage) -  SVG icons for popular brands for your README.md files


### PR DESCRIPTION
Adds [tiennm99/ghstats](https://github.com/tiennm99/ghstats) to the Tools section, next to other GitHub stats card generators.

**What it is:** A Go CLI + GitHub Action that generates 9 themed SVG profile summary cards (profile details, repos-per-language, most-commit-language, stats, productive-time, contributions) with all-time variants. 61+ themes ported from `vn7n24fzkq/github-profile-summary-cards`, byte-weighted commit-to-language attribution, single binary (stdlib only), available on the [GitHub Marketplace](https://github.com/marketplace/actions/ghstats-cards).

**Sample in the wild:** [tiennm99/tiennm99](https://github.com/tiennm99/tiennm99)

Guidelines check:
- [x] Individual PR for this suggestion
- [x] Name starts with a capital
- [x] Spelling & grammar checked
- [x] No trailing whitespace