### PR TITLE
Add agentkit-seo — AI skill for GitHub profile and repo SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@
 - [Todoist Stats in Readme](https://github.com/abhisheknaiidu/todoist-readme) - Daily Todoist Stats on your Profile Readme
 - [Visitor Badge](https://visitor-badge.glitch.me/#docs) - Count visitors for your README.md, Issues, PRs in GitHub
 - [1990s style Visitor Counter](https://twitter.com/ryanlanciaux/status/1283755637126705152) - Add a 1990s style visitor counter with one line of markdown.
+- [agentkit-seo](https://github.com/agentkit-seo/agentkit-seo) - AI agent skill for auditing and optimizing GitHub profiles and repositories. Covers bio, pinned repos, README structure, topics, Copilot instructions, and language stats.
 - [Visitor Count](https://pufler.dev/badge-it/) - Count visitors for README.md that can be used with shields.io
 - [Shields Project](https://shields.io/) - Use Shields to create profile badges, compatible with Simple Icons
 - [Github Readme Stats](https://github.com/anuraghazra/github-readme-stats) - Get dynamically generated GitHub stats on your readmes


### PR DESCRIPTION
AgentKit SEO includes a dedicated GitHub module that agents use to audit and improve GitHub profiles and repositories.

What it covers:
- Profile bio, pinned repos, contribution graph settings
- Repository names, About descriptions, topic tags (up to 20)
- README structure and Copilot instruction files
- Language stats correction via .gitattributes
- Engagement and maintenance signals

Install for Claude Code: `npx agentkit-seo install --provider claude-code`

- MIT licensed
- https://github.com/agentkit-seo/agentkit-seo