### PR TITLE
Add GitHub Project Cards to Tools category

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@
 - [YouTube Channel Stats](https://github.com/DenverCoder1/github-readme-youtube-stats) - 📺 Display number of subscribers on YouTube and/or your channel's view count as a badge
 - [Current Book Status from GoodReads](https://github.com/theFr1nge/goodreads-readme) - Add a card of the current book you are reading that automatically syncs with GoodReads to display your progress.
 - [Readme Typing SVG](https://github.com/DenverCoder1/readme-typing-svg) - :zap: Dynamically generated, customizable SVG that gives the appearance of typing and deleting text
+- [GitHub Project Cards](https://github.com/matheusconaga/github-project-cards) - ✨ Turn GitHub READMEs into modern visual portfolios with customizable project cards
 
 ## Articles
 - ["How To Create A GitHub Profile README"](https://www.aboutmonica.com/blog/how-to-create-a-github-profile-readme) - *Monica Powell*


### PR DESCRIPTION
## What type of PR is this? (check all applicable)


- [ ] 🚀 Added Name
- [ ] ✨ Feature
- [ ] ✅ Joined Community
- [ ] 🌟 ed the repo
- [ ] 🐛 Grammatical Error
- [x] 📝 Documentation Update
- [ ] 🚩 Other

## Description
Added GitHub Project Cards to the Tools category.
A customizable open-source tool for creating modern project cards for GitHub READMEs and portfolios.

## Add Link of GitHub Profile
https://github.com/matheusconaga
