### PR TITLE
Add GitHub Personal Stats under Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@
 - [Visitor Count](https://pufler.dev/badge-it/) - Count visitors for README.md that can be used with shields.io
 - [Shields Project](https://shields.io/) - Use Shields to create profile badges, compatible with Simple Icons
 - [Github Readme Stats](https://github.com/anuraghazra/github-readme-stats) - Get dynamically generated GitHub stats on your readmes
+- [GitHub Personal Stats](https://github.com/liuchong/github-personal-stats) - 📊 Generate a polished SVG profile dashboard with GitHub stats, language share, contributions, and streaks via GitHub Action or CLI
 - [Github Contributor Stats](https://github.com/HwangTaehyun/github-contributor-stats) - :fire: Get dynamically generated Github Contributor stats (repositories you really committed) on your readmes
 - [GitHub Streak Stats](https://github.com/DenverCoder1/github-readme-streak-stats) - 🔥 Stay motivated and show off your contribution streak! 🌟 Display your total contributions, current streak, and longest streak on your GitHub profile README
 - [Simple Icons](https://github.com/simple-icons/simple-icons#cdn-usage) -  SVG icons for popular brands for your README.md files


### PR DESCRIPTION
  ## What type of PR is this? (check all applicable)

  - [ ] 🚀 Added Name
  - [ ] ✨ Feature
  - [ ] ✅ Joined Community
  - [ ] 🌟 ed the repo
  - [ ] 🐛 Grammatical Error
  - [x] 📝 Documentation Update
  - [x] 🚩 Other

  ## Description

  This PR adds [GitHub Personal Stats](https://github.com/liuchong/github-personal-stats) to the Tools section.

  I originally opened a PR to support generating GitHub streak stats through GitHub CI: https://github.com/DenverCoder1/github-readme-streak-stats/pull/904. Since that change may take some time to
  be merged, I built a separate tool that can generate profile stats assets directly from a GitHub Action or local CLI.

  GitHub Personal Stats generates a polished SVG profile dashboard that combines GitHub stats, language share, total contributions, current streak, and longest streak. It also supports individual
  cards for custom README layouts.

  The project was inspired by these existing tools:

  - https://github.com/anuraghazra/github-readme-stats
  - https://github.com/DenverCoder1/github-readme-streak-stats

  ## Add Link of GitHub Profile

  https://github.com/liuchong/github-personal-stats

