### PR TITLE
Add Marcopcode entry in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@
 - [Trini B](https://github.com/trinib/trinib)
 - [holic-x](https://github.com/holic-x/holic-x)
 - [Magrelaio](https://github.com/Magrelaio/Magrelaio)
+- [Marcopcode](https://github.com/marcopcode/marcopcode)
 
 #### Descriptive 🗒
 - [Filip Troníček](https://github.com/filiptronicek/filiptronicek)
@@ -181,6 +182,7 @@
 - [Onimur](https://github.com/onimur/onimur)
 - [Bruno Tacca](https://github.com/brunotacca/brunotacca)
 - [Matthew Taylor](https://github.com/Wrapperup/Wrapperup)
+- [Marcopcode](https://github.com/marcopcode/marcopcode)
 
 #### Typing.. Mode 🎰
 - [Mathieu Ledru](https://github.com/matyo91/matyo91)
@@ -239,6 +241,7 @@
 - [Shahriar Shafin](https://github.com/ShahriarShafin/ShahriarShafin)
 - [Somnath Paul](https://github.com/SP-XD/SP-XD)
 - [Ksenia Morozova](https://github.com/kmoroz/kmoroz)
+- [Marcopcode](https://github.com/marcopcode/marcopcode)
 
 #### Just Images 🎭
 - [Zack Krida](https://github.com/zackkrida/zackkrida)


### PR DESCRIPTION
Add entry for Marcopcode in multiple sections.

## What type of PR is this? (check all applicable)


- [X ] 🚀 Added Name
- [ ] ✨ Feature
- [X ] ✅ Joined Community
- [X ] 🌟 ed the repo
- [ ] 🐛 Grammatical Error
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

Added Marcopcode to GIFs, Simple but Innovative Ones and A Litte Bit of Everything categories. Marcopcode is a corsair style-themed profile with repos containing learning resources in STEM disciplines with focus on Cybersecurity, Cryptography and other related topics along Math, Physics, Electronics and Computer Science disciplines.

## Add Link of GitHub Profile

https://github.com/marcopcode/marcopcode