### PR TITLE
Add Chess Readme Stats link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@
 - [YouTube Channel Stats](https://github.com/DenverCoder1/github-readme-youtube-stats) - 📺 Display number of subscribers on YouTube and/or your channel's view count as a badge
 - [Current Book Status from GoodReads](https://github.com/theFr1nge/goodreads-readme) - Add a card of the current book you are reading that automatically syncs with GoodReads to display your progress.
 - [Readme Typing SVG](https://github.com/DenverCoder1/readme-typing-svg) - :zap: Dynamically generated, customizable SVG that gives the appearance of typing and deleting text
+- [Chess Readme Stats](https://github.com/sxryadipta/chess-readme-stats) - Automatically display your latest Chess.com games and live stats on your GitHub profile README.
+
 
 ## Articles
 - ["How To Create A GitHub Profile README"](https://www.aboutmonica.com/blog/how-to-create-a-github-profile-readme) - *Monica Powell*
@@ -340,6 +342,7 @@
 - ["Static Readme Regeneration"](https://dev.to/aralroca/static-readme-regeneration-4pf2) - *Aral Roca*
 - ["How to Create a Self-Updating README.md for Your GitHub Profile"](https://medium.com/@th.guibert/how-to-create-a-self-updating-readme-md-for-your-github-profile-f8b05744ca91) - *Thomas Guibert*
 - ["一文玩转github主页"](https://blog.holic-x.com/wv-blog/post/7ad96a5d.html) - *holic-x*
+- ["Here's why you need a chess stats card"](https://dev.to/sxryadipta/heres-why-you-need-a-chess-stats-card-4pml) - *Suryadipta Ghosh*
 
 ## Tutorials
 - ["Create Impressive GitHub Portfolio"](https://www.youtube.com/watch?v=dkE4mVhwMB4) - *MTECHVIRAL*


### PR DESCRIPTION
Made a README stats card for chess stats.

## What type of PR is this? (check all applicable)


- [x] 🚀 Added Name
- [ ] ✨ Feature
- [ ] ✅ Joined Community
- [x] 🌟 ed the repo
- [ ] 🐛 Grammatical Error
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description
Added chess-readme-stats to the Tools section — a Next.js tool that automatically displays live Chess.com stats and last game narrative on GitHub profile READMEs. 
Supports both a story mode (auto-updates via GitHub Actions) and a card mode (single image embed, no setup needed).


## Add Link of GitHub Profile
[sxryadipta](https://github.com/sxryadipta)
