### PR TITLE
Add Profile Counter to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@
 - [Visitor Badge](https://visitor-badge.glitch.me/#docs) - Count visitors for your README.md, Issues, PRs in GitHub
 - [1990s style Visitor Counter](https://twitter.com/ryanlanciaux/status/1283755637126705152) - Add a 1990s style visitor counter with one line of markdown.
 - [Visitor Count](https://pufler.dev/badge-it/) - Count visitors for README.md that can be used with shields.io
+- [Profile Counter](https://github.com/othmarodev/profile-counter) - Self-hosted GitHub profile views counter — drop-in replacement for komarev/laobi. You own the URL and the data. Vercel Edge + Upstash Redis. Includes migration script to seed your old count so you don't lose historical visits.
 - [Shields Project](https://shields.io/) - Use Shields to create profile badges, compatible with Simple Icons
 - [Github Readme Stats](https://github.com/anuraghazra/github-readme-stats) - Get dynamically generated GitHub stats on your readmes
 - [Github Contributor Stats](https://github.com/HwangTaehyun/github-contributor-stats) - :fire: Get dynamically generated Github Contributor stats (repositories you really committed) on your readmes


### PR DESCRIPTION
Adding **Profile Counter** to the Tools section, alphabetically near the other visitor counter entries (Visitor Badge, Visitor Count).

## What it is

[Profile Counter](https://github.com/othmarodev/profile-counter) is a self-hosted GitHub profile views counter — a drop-in replacement for komarev.com/ghpvc that you deploy to your own Vercel + Upstash Redis (both free tier).

- **Live demo**: https://counter.othmaro.dev
- **Source**: https://github.com/othmarodev/profile-counter
- **License**: MIT

## Why it might fit this list

The Tools section already lists 3 visitor counter services (Visitor Badge, 1990s style, Visitor Count) — all of them third-party hosted. Every few months one of them goes down and users lose their count. profile-counter solves the same problem but **self-hosted** — the user owns the URL (on their own domain) and the data (their own Redis), and ships with a migration script to preserve their old count from komarev/laobi when those break.

It's ~300 lines of vanilla JavaScript with a Deploy with Vercel button for one-click setup.

Format follows the convention from CONTRIBUTING.md (`[Name](link) - Description`, capital name, no trailing whitespace).

Thanks for maintaining this list! 🙏