### PR TITLE
Add Three Readme to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@
 - [YouTube Channel Stats](https://github.com/DenverCoder1/github-readme-youtube-stats) - 📺 Display number of subscribers on YouTube and/or your channel's view count as a badge
 - [Current Book Status from GoodReads](https://github.com/theFr1nge/goodreads-readme) - Add a card of the current book you are reading that automatically syncs with GoodReads to display your progress.
 - [Readme Typing SVG](https://github.com/DenverCoder1/readme-typing-svg) - :zap: Dynamically generated, customizable SVG that gives the appearance of typing and deleting text
+- [Three Readme](https://github.com/kpab/three-readme) - Render genuine Three.js scenes as animated SVGs to embed in your README
 
 ## Articles
 - ["How To Create A GitHub Profile README"](https://www.aboutmonica.com/blog/how-to-create-a-github-profile-readme) - *Monica Powell*


### PR DESCRIPTION
Adds **Three Readme** to the end of the *Tools* section.

Three Readme is a GitHub Action / CLI that renders genuine Three.js scenes into animated SVGs (SMIL) and commits them back into your repo for embedding in a README. It bakes real 3D rendering into a self-contained SVG that animates on both light and dark GitHub themes — distinct from the static badge/stat tools in the list (live gallery and demos in the repo).

- One suggestion in this PR.
- Name capitalized; trailing whitespace removed.