### PR TITLE
Add GitHub Readme LeetCode Stats to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@
 - [Github Readme Stats](https://github.com/anuraghazra/github-readme-stats) - Get dynamically generated GitHub stats on your readmes
 - [Github Contributor Stats](https://github.com/HwangTaehyun/github-contributor-stats) - :fire: Get dynamically generated Github Contributor stats (repositories you really committed) on your readmes
 - [GitHub Streak Stats](https://github.com/DenverCoder1/github-readme-streak-stats) - 🔥 Stay motivated and show off your contribution streak! 🌟 Display your total contributions, current streak, and longest streak on your GitHub profile README
+- [GitHub Readme LeetCode Stats](https://github.com/blackscythe123/github-readme-leetcode-stats) - Composable LeetCode dashboard card for your GitHub README (solved stats, streak, skills, heatmap), self-hosted with 160+ themes
 - [Simple Icons](https://github.com/simple-icons/simple-icons#cdn-usage) -  SVG icons for popular brands for your README.md files
 - [Laravel GitHub Profile Visit Counter](https://github.com/caneco/laravel-github-profile-view-counter) - Add on your Laravel project a quick-badge to count your profile visits.
 - [Dev Metrics in Readme](https://github.com/athul/waka-readme) - [WakaTime](https://wakatime.com/) Weekly Metrics on your Profile Readme


### PR DESCRIPTION
Adding a tool I built for showing LeetCode progress on a GitHub profile.

There's a popular streak-stats card for GitHub contributions (already listed here) but nothing similar existed for LeetCode with a real theme catalog, so I built one. It renders solved stats, current/highest streak, skill tags, and a submission heatmap as an SVG, and you can turn individual sections on or off depending on what you want to show.

Live example: https://github.com/blackscythe123
Repo: https://github.com/blackscythe123/github-readme-leetcode-stats

It's self-hosted (your own Vercel deployment, your own LeetCode username), MIT licensed, and has a one-click deploy button for anyone who wants their own instance.

Placed it right under GitHub Streak Stats in the Tools section since it's the same idea applied to LeetCode instead of GitHub contributions.