### PR TITLE
Add GitHub Profile Stats link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@
 - [YouTube Channel Stats](https://github.com/DenverCoder1/github-readme-youtube-stats) - 📺 Display number of subscribers on YouTube and/or your channel's view count as a badge
 - [Current Book Status from GoodReads](https://github.com/theFr1nge/goodreads-readme) - Add a card of the current book you are reading that automatically syncs with GoodReads to display your progress.
 - [Readme Typing SVG](https://github.com/DenverCoder1/readme-typing-svg) - :zap: Dynamically generated, customizable SVG that gives the appearance of typing and deleting text
+- [GitHub Profile Stats](https://github.com/rowkav09/GitHub-profile-stats) - Free, real-time GitHub stat cards, language charts, mini badges & activity sparklines for your README. No token, no setup - just paste one line. [Live demo](https://ghstats.dev)
 
 ## Articles
 - ["How To Create A GitHub Profile README"](https://www.aboutmonica.com/blog/how-to-create-a-github-profile-readme) - *Monica Powell*


### PR DESCRIPTION
Adds GitHub Profile Stats to the Tools section — a free, open-source (MIT) tool that generates real-time GitHub stat cards, language charts, mini badges, and activity sparklines for your README. No personal access token or deployment needed; you just paste one line. It also includes a live on-page builder for themes and options.

Repo: https://github.com/rowkav09/GitHub-profile-stats
Live demo: https://ghstats.dev