### PR TITLE
Add github-candles to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@
 - [YouTube Channel Stats](https://github.com/DenverCoder1/github-readme-youtube-stats) - 📺 Display number of subscribers on YouTube and/or your channel's view count as a badge
 - [Current Book Status from GoodReads](https://github.com/theFr1nge/goodreads-readme) - Add a card of the current book you are reading that automatically syncs with GoodReads to display your progress.
 - [Readme Typing SVG](https://github.com/DenverCoder1/readme-typing-svg) - :zap: Dynamically generated, customizable SVG that gives the appearance of typing and deleting text
+- [github-candles](https://github.com/starlash7/github-candles) - Render your GitHub contributions as a self-updating trading candlestick chart.
 
 ## Articles
 - ["How To Create A GitHub Profile README"](https://www.aboutmonica.com/blog/how-to-create-a-github-profile-readme) - *Monica Powell*


### PR DESCRIPTION
## What type of PR is this? (check all applicable)


- [ ] 🚀 Added Name
- [ ] ✨ Feature
- [ ] ✅ Joined Community
- [x] 🌟 ed the repo
- [ ] 🐛 Grammatical Error
- [ ] 📝 Documentation Update
- [x] 🚩 Other

## Description

Adds **github-candles** to the Tools section — a tool that renders 
your GitHub contributions as a self-updating trading candlestick 
chart (weekly OHLC, volume bars, exchange-style UI).

- Single Python file, zero dependencies
- Self-updates daily via GitHub Actions on the default token
- Zero config — auto-detects the repo owner
- MIT licensed

Repo: https://github.com/starlash7/github-candles

## Add Link of GitHub Profile

https://github.com/starlash7