### PR TITLE
Add Markdown Tools GitHub Profile README

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@
 - [YouTube Channel Stats](https://github.com/DenverCoder1/github-readme-youtube-stats) - 📺 Display number of subscribers on YouTube and/or your channel's view count as a badge
 - [Current Book Status from GoodReads](https://github.com/theFr1nge/goodreads-readme) - Add a card of the current book you are reading that automatically syncs with GoodReads to display your progress.
 - [Readme Typing SVG](https://github.com/DenverCoder1/readme-typing-svg) - :zap: Dynamically generated, customizable SVG that gives the appearance of typing and deleting text
+- [Markdown Tools GitHub Profile README](https://www.markdowntools.io/github-profile-readme) - Free browser-based generator for GitHub profile READMEs; no signup, nothing uploaded.
 
 ## Articles
 - ["How To Create A GitHub Profile README"](https://www.aboutmonica.com/blog/how-to-create-a-github-profile-readme) - *Monica Powell*


### PR DESCRIPTION
Adds [Markdown Tools GitHub Profile README](https://www.markdowntools.io/github-profile-readme) to the bottom of the Tools section.

Free browser-based generator for GitHub profile READMEs — no signup, and everything runs locally so nothing is uploaded. One suggestion in this PR, per the contribution guidelines.
