### PR TITLE
Add Daily Badge to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@
 - [YouTube Channel Stats](https://github.com/DenverCoder1/github-readme-youtube-stats) - 📺 Display number of subscribers on YouTube and/or your channel's view count as a badge
 - [Current Book Status from GoodReads](https://github.com/theFr1nge/goodreads-readme) - Add a card of the current book you are reading that automatically syncs with GoodReads to display your progress.
 - [Readme Typing SVG](https://github.com/DenverCoder1/readme-typing-svg) - :zap: Dynamically generated, customizable SVG that gives the appearance of typing and deleting text
+- [Daily Badge](https://github.com/in-c0/daily-badge) - A new quirky "on this day" message on your profile every day, in your timezone. One URL, no fork needed.
 
 ## Articles
 - ["How To Create A GitHub Profile README"](https://www.aboutmonica.com/blog/how-to-create-a-github-profile-readme) - *Monica Powell*


### PR DESCRIPTION
Adds **Daily Badge** to the Tools section.

It puts a new quirky "on this day" message on your GitHub profile every day, rendered in your own timezone. Setup is a single URL — no fork, no Actions cron, no per-user infrastructure:

```markdown
![Daily Badge](https://daily-badge.wldud5192.workers.dev/badge.svg?tz=Australia/Sydney)
```

There's also a live customizer (pick timezone/pack/style/color): https://in-c0.github.io/daily-badge/

Sits naturally alongside existing fun entries like *README Jokes*, *GitHub Readme Quotes*, and *Random Dev Memes*. Single-line addition at the end of the Tools list. Thanks for maintaining this list! 🙌