### PR TITLE
Add Dither Portrait to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@
 - [YouTube Channel Stats](https://github.com/DenverCoder1/github-readme-youtube-stats) - 📺 Display number of subscribers on YouTube and/or your channel's view count as a badge
 - [Current Book Status from GoodReads](https://github.com/theFr1nge/goodreads-readme) - Add a card of the current book you are reading that automatically syncs with GoodReads to display your progress.
 - [Readme Typing SVG](https://github.com/DenverCoder1/readme-typing-svg) - :zap: Dynamically generated, customizable SVG that gives the appearance of typing and deleting text
+- [Dither Portrait](https://github.com/0xharkirat/dither-portrait) - Turn a photo into an animated dithered SVG for your profile README, with a browser playground to preview it
 
 ## Articles
 - ["How To Create A GitHub Profile README"](https://www.aboutmonica.com/blog/how-to-create-a-github-profile-readme) - *Monica Powell*


### PR DESCRIPTION
Adds [Dither Portrait](https://github.com/0xharkirat/dither-portrait) to the Tools section.

It is a GitHub Action that turns a photo into an animated dithered SVG for a profile README. Light and dark variants, transparent background, and it honours `prefers-reduced-motion`.

There is a browser playground at https://0xharkirat.github.io/dither-portrait/ that dithers a photo locally and hands back the matching workflow, so it can be tried without installing anything.

Checked against the contribution guidelines: one suggestion in one pull request, name capitalised, no trailing whitespace, and the diff is a single added line.