### PR TITLE
Add GitHub Readme Zodiac tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@
 - [YouTube Channel Stats](https://github.com/DenverCoder1/github-readme-youtube-stats) - 📺 Display number of subscribers on YouTube and/or your channel's view count as a badge
 - [Current Book Status from GoodReads](https://github.com/theFr1nge/goodreads-readme) - Add a card of the current book you are reading that automatically syncs with GoodReads to display your progress.
 - [Readme Typing SVG](https://github.com/DenverCoder1/readme-typing-svg) - :zap: Dynamically generated, customizable SVG that gives the appearance of typing and deleting text
+- [GitHub Readme Zodiac](https://github.com/seuthootDev/github-readme-zodiac) - Zodiac-themed SVG profile cards and pinned Gists from your GitHub activity.
+- [GitHub Readme Chinese Zodiac](https://github.com/seuthootDev/github-readme-chinese-zodiac) - Asian zodiac (十二生肖) SVG profile cards and pinned Gists from your GitHub activity.
 
 ## Articles
 - ["How To Create A GitHub Profile README"](https://www.aboutmonica.com/blog/how-to-create-a-github-profile-readme) - *Monica Powell*


### PR DESCRIPTION
﻿## Summary
- Add [GitHub Readme Zodiac](https://github.com/seuthootDev/github-readme-zodiac) to Tools
- Add [GitHub Readme Chinese Zodiac](https://github.com/seuthootDev/github-readme-chinese-zodiac) to Tools

Sister projects that generate zodiac-themed SVG profile cards (and optional pinned Gists) from public GitHub activity.

## Checklist
- [x] Spelling / grammar checked
- [x] Individual tools listed under Tools
