### PR TITLE
Add Github Pet to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,8 @@
 - [Current Book Status from GoodReads](https://github.com/theFr1nge/goodreads-readme) - Add a card of the current book you are reading that automatically syncs with GoodReads to display your progress.
 - [Readme Typing SVG](https://github.com/DenverCoder1/readme-typing-svg) - :zap: Dynamically generated, customizable SVG that gives the appearance of typing and deleting text
 
+- [Github Pet](https://github.com/prsdx/github-pet) - Animated pixel cat for your GitHub profile README that reacts to real activity (CI failures, streaks, releases) - zero-dependency animated SVGs via a GitHub Action.
+
 ## Articles
 - ["How To Create A GitHub Profile README"](https://www.aboutmonica.com/blog/how-to-create-a-github-profile-readme) - *Monica Powell*
 - ["How to Stand Out on Github with Profile READMEs"](https://medium.com/better-programming/how-to-stand-out-on-github-with-profile-readmes-dfd2102a3490?source=friends_link&sk=61df9c4b63b329ad95528b8d7c00061f) - *Jessica Lim*


### PR DESCRIPTION
github-pet is a zero-dependency pixel pet that lives on GitHub profile READMEs and reacts to real activity: CI failures (overheat), contribution streaks (campfire), releases (trophy), day/night sky, isometric contribution city. Ships as a GitHub Action (uses: prsdx/github-pet@v1) - SVGs regenerate every 6h in the adopter's own repo. MIT licensed, live demo on the author's profile.