### PR TITLE
Add GitHub Stats xCards to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,8 @@
 - [Github Readme Stats](https://github.com/anuraghazra/github-readme-stats) - Get dynamically generated GitHub stats on your readmes
 - [Github Contributor Stats](https://github.com/HwangTaehyun/github-contributor-stats) - :fire: Get dynamically generated Github Contributor stats (repositories you really committed) on your readmes
 - [GitHub Streak Stats](https://github.com/DenverCoder1/github-readme-streak-stats) - 🔥 Stay motivated and show off your contribution streak! 🌟 Display your total contributions, current streak, and longest streak on your GitHub profile README
-- [Simple Icons](https://github.com/simple-icons/simple-icons#cdn-usage) -  SVG icons for popular brands for your README.md files
+- [GitHub Stats xCards](https://github.com/LuiisDev21/gh-stats-xcards) - 🎮 Gamified SVG stats cards for your profile README: level & XP ranks (Bronze → Legend), streaks, contribution graph and top languages
+- [Simple Icons](https://github.com/simple-icons/simple-icons#cdn-usage) - SVG icons for popular brands for your README.md files
 - [Laravel GitHub Profile Visit Counter](https://github.com/caneco/laravel-github-profile-view-counter) - Add on your Laravel project a quick-badge to count your profile visits.
 - [Dev Metrics in Readme](https://github.com/athul/waka-readme) - [WakaTime](https://wakatime.com/) Weekly Metrics on your Profile Readme
 - [Profile Activity Generator](https://github.com/omidnikrah/profile-activity-generator) - Generate custom profile activity for your profile README


### PR DESCRIPTION
### What
Adds [gh-stats-xcards](https://github.com/LuiisDev21/gh-stats-xcards) to the Tools section.

### Why
A self-hostable, gamified alternative to classic stats cards: level/XP ranks (Bronze → Legend), streak, contribution graph, top languages and profile cards as live SVGs (FastAPI + GitHub GraphQL). Live demo: https://gh-stats-xcards.fly.dev