### PR TITLE
Add gitglance to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@
 - [Github Readme Stats](https://github.com/anuraghazra/github-readme-stats) - Get dynamically generated GitHub stats on your readmes
 - [Github Contributor Stats](https://github.com/HwangTaehyun/github-contributor-stats) - :fire: Get dynamically generated Github Contributor stats (repositories you really committed) on your readmes
 - [GitHub Streak Stats](https://github.com/DenverCoder1/github-readme-streak-stats) - 🔥 Stay motivated and show off your contribution streak! 🌟 Display your total contributions, current streak, and longest streak on your GitHub profile README
+- [gitglance](https://github.com/rafaeloliveiraz/gitglance) - Self-hostable GitHub stats cards with 16 visual styles, 21 themes, chart cards (donut, gauges, commit activity) and a visual card builder
 - [Simple Icons](https://github.com/simple-icons/simple-icons#cdn-usage) -  SVG icons for popular brands for your README.md files
 - [Laravel GitHub Profile Visit Counter](https://github.com/caneco/laravel-github-profile-view-counter) - Add on your Laravel project a quick-badge to count your profile visits.
 - [Dev Metrics in Readme](https://github.com/athul/waka-readme) - [WakaTime](https://wakatime.com/) Weekly Metrics on your Profile Readme


### PR DESCRIPTION
Adds [gitglance](https://github.com/rafaeloliveiraz/gitglance) to the Tools section.

gitglance is an open-source (MIT), self-hostable service that renders GitHub stats cards as SVG for profile READMEs: 16 visual styles (vercel, terminal, glass, neon, aurora and more), 21 color themes, and 8 card types including donut charts, circular gauges, a repository pin and a commit activity chart. It also ships a visual card builder page where users assemble their card and copy the markdown.

Live builder: https://gitglance-eight.vercel.app

Thanks for maintaining this list!