### PR TITLE
Add awesometime to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@
 - [YouTube Channel Stats](https://github.com/DenverCoder1/github-readme-youtube-stats) - 📺 Display number of subscribers on YouTube and/or your channel's view count as a badge
 - [Current Book Status from GoodReads](https://github.com/theFr1nge/goodreads-readme) - Add a card of the current book you are reading that automatically syncs with GoodReads to display your progress.
 - [Readme Typing SVG](https://github.com/DenverCoder1/readme-typing-svg) - :zap: Dynamically generated, customizable SVG that gives the appearance of typing and deleting text
+- [awesometime](https://github.com/tiger-dreams/awesometime) - Zero-dependency SVG badge generator for GitHub READMEs, showing a year progress bar or a countdown to any date, with terminal/gradient/minimal styles and light/dark themes.
 
 ## Articles
 - ["How To Create A GitHub Profile README"](https://www.aboutmonica.com/blog/how-to-create-a-github-profile-readme) - *Monica Powell*


### PR DESCRIPTION
## What
Adds one entry for [`awesometime`](https://github.com/tiger-dreams/awesometime) to the **Tools** section, alongside similar dynamic-badge generators (Github Readme Stats, GitHub Streak Stats, Shields Project, etc.).

## What it is
A zero-dependency Node.js library + Vercel edge API that generates dynamic SVG badges for GitHub READMEs: a "year progress" bar (days elapsed/remaining in the current calendar year) and a "countdown to any date" card. Three visual styles (terminal/gradient/minimal), light/dark themes, custom color overrides via query params, and English/Korean locale support.

- Live demo / embeddable badge: https://awesometime.vercel.app/api
- Embed as: `![Year Progress](https://awesometime.vercel.app/api)`

This is a new project (no stars yet) — flagging that directly rather than overselling it. Adding it here because it fits the existing "Tools" list of dynamic README badge/content generators.

## Diff
One line added at the end of the `## Tools` list, before `## Articles`. No other content changed, moved, or removed.