### PR TITLE
Add vinilo to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@
 - [YouTube Channel Stats](https://github.com/DenverCoder1/github-readme-youtube-stats) - 📺 Display number of subscribers on YouTube and/or your channel's view count as a badge
 - [Current Book Status from GoodReads](https://github.com/theFr1nge/goodreads-readme) - Add a card of the current book you are reading that automatically syncs with GoodReads to display your progress.
 - [Readme Typing SVG](https://github.com/DenverCoder1/readme-typing-svg) - :zap: Dynamically generated, customizable SVG that gives the appearance of typing and deleting text
+- [vinilo](https://github.com/icortesb/vinilo) - Your recently played Spotify tracks as a static SVG, built in your own GitHub Actions and committed to your own branch, so no third-party service holds your token
 
 ## Articles
 - ["How To Create A GitHub Profile README"](https://www.aboutmonica.com/blog/how-to-create-a-github-profile-readme) - *Monica Powell*


### PR DESCRIPTION
Adds [vinilo](https://github.com/icortesb/vinilo) to the Tools list.

It renders your recently played Spotify tracks as a static SVG. Unlike the hosted cards already on the list, it runs as a GitHub Action inside your own repository: the SVG is built in your workflow and committed to a branch of yours, so no third-party service stores your refresh token or sits in the request path. If Spotify errors or rate-limits, it publishes nothing and the previously committed card stays intact rather than becoming an error image.

Public, MIT licensed, and on the GitHub Marketplace. One entry, appended to the end of Tools, no trailing whitespace.